### PR TITLE
[#43] refactor: 실패 기록 조회에서 response형태 변경

### DIFF
--- a/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
+++ b/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
@@ -1,0 +1,29 @@
+package com.todaysfailbe.member.model.response;
+
+import com.todaysfailbe.member.domain.Member;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ApiModel
+@ToString
+@NoArgsConstructor
+public class MemberDto {
+	private Long id;
+
+	private String name;
+
+	private MemberDto(Long id, String name) {
+		this.id = id;
+		this.name = name;
+	}
+
+	public static MemberDto from(Member member) {
+		return new MemberDto(member.getId(), member.getName());
+	}
+}

--- a/src/main/java/com/todaysfailbe/record/controller/RecordController.java
+++ b/src/main/java/com/todaysfailbe/record/controller/RecordController.java
@@ -1,8 +1,6 @@
 package com.todaysfailbe.record.controller;
 
-import java.time.LocalDate;
 import java.util.List;
-import java.util.concurrent.ConcurrentMap;
 
 import javax.validation.Valid;
 
@@ -15,10 +13,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
 import com.todaysfailbe.record.model.request.DeleteRecordRequest;
 import com.todaysfailbe.record.model.request.RecordsRequest;
+import com.todaysfailbe.record.model.response.RecordsResponse;
 import com.todaysfailbe.record.service.RecordService;
 
 import io.swagger.annotations.ApiOperation;
@@ -67,10 +65,9 @@ public class RecordController {
 			)
 	})
 	@GetMapping
-	public ResponseEntity<ConcurrentMap<LocalDate, List<Record>>> getRecords(
-			@RequestBody @Valid RecordsRequest recordsRequest) {
+	public ResponseEntity<List<RecordsResponse>> getRecords(@Valid RecordsRequest recordsRequest) {
 		log.info("[RecordController.getRecords] 레코드 목록 조회 요청");
-		ConcurrentMap<LocalDate, List<Record>> response = recordService.getRecords(recordsRequest);
+		List<RecordsResponse> response = recordService.getRecords(recordsRequest);
 		log.info("[RecordController.getRecords] 레코드 목록 조회 성공");
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}

--- a/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
@@ -5,16 +5,12 @@ import javax.validation.constraints.NotBlank;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@Builder
 @ApiModel
 @ToString
-@NoArgsConstructor
 @AllArgsConstructor
 public class RecordsRequest {
 	@NotBlank(message = "작성자는 필수입니다.")

--- a/src/main/java/com/todaysfailbe/record/model/response/RecordDto.java
+++ b/src/main/java/com/todaysfailbe/record/model/response/RecordDto.java
@@ -1,0 +1,55 @@
+package com.todaysfailbe.record.model.response;
+
+import com.todaysfailbe.member.model.response.MemberDto;
+import com.todaysfailbe.record.domain.Record;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ApiModel
+@ToString
+@NoArgsConstructor
+public class RecordDto {
+	@ApiModelProperty(value = "실패 기록 ID", required = true, example = "1")
+	private Long id;
+
+	@ApiModelProperty(value = "실패 기록 제목", required = true, example = "핫케이크 태움")
+	private String title;
+
+	@ApiModelProperty(value = "실패 기록 내용", required = true, example = "핫케이크를 타다가 불이 났다.")
+	private String content;
+
+	@ApiModelProperty(value = "실패 기록 느낀점", required = true, example = "다음에 더 잘하면 된다")
+	private String feel;
+
+	@ApiModelProperty(value = "실패 기록 시:분:초", required = true, example = "19:31:51")
+	private String createdAt;
+
+	private MemberDto member;
+
+	public RecordDto(Long id, String title, String content, String feel, String createdAt, MemberDto member) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.feel = feel;
+		this.createdAt = createdAt;
+		this.member = member;
+	}
+
+	public static RecordDto from(Record record, String createdAt, MemberDto memberDto) {
+		return new RecordDto(
+				record.getId(),
+				record.getTitle(),
+				record.getTitle(),
+				record.getFeel(),
+				createdAt,
+				memberDto
+		);
+	}
+}

--- a/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
+++ b/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
@@ -1,0 +1,30 @@
+package com.todaysfailbe.record.model.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.swagger.annotations.ApiModel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ApiModel
+@ToString
+@NoArgsConstructor
+public class RecordsResponse {
+	private LocalDate date;
+
+	private List<RecordDto> records;
+
+	private RecordsResponse(LocalDate date, List<RecordDto> records) {
+		this.date = date;
+		this.records = records;
+	}
+
+	public static RecordsResponse from(LocalDate date, List<RecordDto> records) {
+		return new RecordsResponse(date, records);
+	}
+}


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
실패 기록 조회에서 response형태 변경
 - 필요 없는 값들까지 같이 넘어가서 response 객체 생성 후 바인딩해서 응답
## 📋 진행 사항
- [x] 실패 기록 조회시 response 형태 변경
- [x] RecordController에 getRecords 메서드 기존 body로 받도록 잘못되어있던거 수정

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
