### PR TITLE
[#45] rafactor: 영수증 뽑기 시 현재 날짜 대신 해당 영수증의 날짜로 변경

### DIFF
--- a/src/main/java/com/todaysfailbe/common/utils/DateTimeUtil.java
+++ b/src/main/java/com/todaysfailbe/common/utils/DateTimeUtil.java
@@ -13,8 +13,7 @@ public class DateTimeUtil {
 		return LocalDateTime.of(date, LocalTime.MAX);
 	}
 
-	public static String yearMonthDateConversion(LocalDateTime localDateTime) {
-		LocalDate localDate = localDateTime.toLocalDate();
+	public static String yearMonthDateConversion(LocalDate localDate) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(localDate.getMonth().toString() + " ");
 		sb.append(String.format("%02d", localDate.getMonthValue()) + " - ");

--- a/src/main/java/com/todaysfailbe/receipt/domain/Receipt.java
+++ b/src/main/java/com/todaysfailbe/receipt/domain/Receipt.java
@@ -1,5 +1,6 @@
 package com.todaysfailbe.receipt.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -36,12 +37,16 @@ public class Receipt extends BaseEntity {
 	@ElementCollection
 	private List<Long> recordIds;
 
-	private Receipt(List<Long> recordIds) {
+	private LocalDate receiptDate;
+
+	private Receipt(List<Long> recordIds, LocalDate receiptDate) {
 		Assert.notNull(recordIds, "실패 기록 ID 리스트는 필수입니다.");
+		Assert.notNull(receiptDate, "영수증 발급일은 필수입니다.");
 		this.recordIds = recordIds;
+		this.receiptDate = receiptDate;
 	}
 
-	public static Receipt from(List<Long> recordIds) {
-		return new Receipt(recordIds);
+	public static Receipt from(List<Long> recordIds, LocalDate receiptDate) {
+		return new Receipt(recordIds, receiptDate);
 	}
 }

--- a/src/main/java/com/todaysfailbe/receipt/service/ReceiptService.java
+++ b/src/main/java/com/todaysfailbe/receipt/service/ReceiptService.java
@@ -49,7 +49,7 @@ public class ReceiptService {
 			throw new IllegalArgumentException("해당 날짜에 해당하는 실패 기록이 없습니다.");
 		}
 
-		Receipt receipt = receiptRepository.save(Receipt.from(list));
+		Receipt receipt = receiptRepository.save(Receipt.from(list, request.getDate()));
 		log.info("[ReceiptService.createReceipt] 영수증 등록 완료: {}", request);
 		return receipt.getId().toString();
 	}
@@ -66,7 +66,7 @@ public class ReceiptService {
 
 		ReceiptResponse response = ReceiptResponse.from(
 				receiptDtoList,
-				yearMonthDateConversion(receipt.getCreatedAt()),
+				yearMonthDateConversion(receipt.getReceiptDate()),
 				receiptId
 		);
 		log.info("[ReceiptService.getReceipt] 영수증 조회 완료: {}", response);


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
영수증 뽑기 시 시간 값이 현재 시간으로 들어가는데,
영수증 조회 시 영수증 추출 날짜가 아닌 해당 실패 기록들의 날짜가 들어가야해서 변경하려고합니다.

## 📋 진행 사항
- [x] Receipt entity에 LocalDate 컬럼 추가
- [x] 영수증 등록과 영수증 조회 시 새로 생긴 컬럼의 LocalDate 값 사용하도록 변경 

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
