### PR TITLE
[#55] refactor: 실패 기록 조회 시 날짜가 있다면 날짜에 해당하는 실패 기록만 조회

### DIFF
--- a/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
@@ -1,6 +1,10 @@
 package com.todaysfailbe.record.model.request;
 
+import java.time.LocalDate;
+
 import javax.validation.constraints.NotBlank;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -16,4 +20,8 @@ public class RecordsRequest {
 	@NotBlank(message = "작성자는 필수입니다.")
 	@ApiModelProperty(value = "작성자", required = true, example = "주니")
 	private String writer;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@ApiModelProperty(value = "조회 할 날짜", example = "2023-02-26")
+	private LocalDate date;
 }

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -47,15 +47,10 @@ public class RecordService {
 		log.info("[RecordService.getRecords] 레코드 목록 조회 요청");
 		Member member = memberRepository.findByName(request.getWriter())
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member).stream()
-				.collect(Collectors.groupingByConcurrent(
-						record -> {
-							LocalDateTime dateTime = record.getCreatedAt();
-							return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
-						}
-				));
 
 		List<RecordsResponse> response = new ArrayList<>();
+
+		ConcurrentMap<LocalDate, List<Record>> map = ifThereIsADateSearchByDateGetList(request, member);
 
 		for (LocalDate date : map.keySet()) {
 			List<RecordDto> records = map.get(date).stream()
@@ -74,6 +69,37 @@ public class RecordService {
 
 		log.info("[RecordService.getRecords] 레코드 목록 조회 성공");
 		return response;
+	}
+
+	private ConcurrentMap<LocalDate, List<Record>> ifThereIsADateSearchByDateGetList(
+			RecordsRequest request,
+			Member member
+	) {
+		if (request.getDate() != null) {
+			LocalDate date = request.getDate();
+			ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMemberAndCreatedAtBetween(member,
+							DateTimeUtil.getStartOfDay(date), DateTimeUtil.getEndOfDay(date))
+					.stream()
+					.collect(Collectors.groupingByConcurrent(
+									record -> {
+										LocalDateTime dateTime = record.getCreatedAt();
+										return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
+									}
+							)
+					);
+			return map;
+		}
+
+		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member)
+				.stream()
+				.collect(Collectors.groupingByConcurrent(
+								record -> {
+									LocalDateTime dateTime = record.getCreatedAt();
+									return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
+								}
+						)
+				);
+		return map;
 	}
 
 	@Transactional


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
기존 실패 기록 조회 시 해당 사용자의 모든 날짜의 실패 기록만 불러왔는데,
영수증 뽑기 전 페이지에서 하루 날짜에 대한 내용만 필요하여 수정하였습니다.
- 실패 기록 조회 시 날짜가 있다면 날짜에 해당하는 실패 기록만 조회하도록 변경

## 📋 진행 사항
- [x] 실패 기록 조회 시 날짜가 있다면 날짜에 해당하는 실패 기록만 조회하도록 변경

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
