### PR TITLE
delivery: v0.0.2배포

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com'
-version = '0.0.1-SNAPSHOT'
+version = '0.0.2-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {

--- a/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
+++ b/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
@@ -3,6 +3,7 @@ package com.todaysfailbe.member.model.response;
 import com.todaysfailbe.member.domain.Member;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,8 +15,10 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 public class MemberDto {
+	@ApiModelProperty(value = "실패 기록한 회원 정보", required = true, example = "1")
 	private Long id;
 
+	@ApiModelProperty(value = "실패 기록한 회원 정보", required = true, example = "도모")
 	private String name;
 
 	private MemberDto(Long id, String name) {

--- a/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
+++ b/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
@@ -15,10 +15,10 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 public class MemberDto {
-	@ApiModelProperty(value = "실패 기록한 회원 정보", required = true, example = "1")
+	@ApiModelProperty(value = "회원 ID", required = true, example = "1")
 	private Long id;
 
-	@ApiModelProperty(value = "실패 기록한 회원 정보", required = true, example = "도모")
+	@ApiModelProperty(value = "회원 이름", required = true, example = "도모")
 	private String name;
 
 	private MemberDto(Long id, String name) {

--- a/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/RecordsRequest.java
@@ -1,6 +1,10 @@
 package com.todaysfailbe.record.model.request;
 
+import java.time.LocalDate;
+
 import javax.validation.constraints.NotBlank;
+
+import org.springframework.format.annotation.DateTimeFormat;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -16,4 +20,8 @@ public class RecordsRequest {
 	@NotBlank(message = "작성자는 필수입니다.")
 	@ApiModelProperty(value = "작성자", required = true, example = "주니")
 	private String writer;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	@ApiModelProperty(value = "조회 할 날짜", example = "2023-02-26")
+	private LocalDate date;
 }

--- a/src/main/java/com/todaysfailbe/record/model/response/RecordDto.java
+++ b/src/main/java/com/todaysfailbe/record/model/response/RecordDto.java
@@ -31,6 +31,7 @@ public class RecordDto {
 	@ApiModelProperty(value = "실패 기록 시:분:초", required = true, example = "19:31:51")
 	private String createdAt;
 
+	@ApiModelProperty(value = "실패 기록한 회원 정보", required = true)
 	private MemberDto member;
 
 	public RecordDto(Long id, String title, String content, String feel, String createdAt, MemberDto member) {

--- a/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
+++ b/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,16 +16,22 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 public class RecordsResponse {
+	@ApiModelProperty(value = "실패 기록 날짜", required = true, example = "2023-02-27")
 	private LocalDate date;
 
+	@ApiModelProperty(value = "실패 기록 리스트", required = true)
 	private List<RecordDto> records;
 
-	private RecordsResponse(LocalDate date, List<RecordDto> records) {
+	@ApiModelProperty(value = "영수증 날짜", required = true, example = "FEBRUARY 02 - 27, 2023")
+	private String receiptDate;
+
+	private RecordsResponse(LocalDate date, List<RecordDto> records, String receiptDate) {
 		this.date = date;
 		this.records = records;
+		this.receiptDate = receiptDate;
 	}
 
-	public static RecordsResponse from(LocalDate date, List<RecordDto> records) {
-		return new RecordsResponse(date, records);
+	public static RecordsResponse from(LocalDate date, List<RecordDto> records, String receiptDate) {
+		return new RecordsResponse(date, records, receiptDate);
 	}
 }

--- a/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
+++ b/src/main/java/com/todaysfailbe/record/model/response/RecordsResponse.java
@@ -25,13 +25,17 @@ public class RecordsResponse {
 	@ApiModelProperty(value = "영수증 날짜", required = true, example = "FEBRUARY 02 - 27, 2023")
 	private String receiptDate;
 
-	private RecordsResponse(LocalDate date, List<RecordDto> records, String receiptDate) {
+	@ApiModelProperty(value = "실패 기록 총 개수", required = true, example = "19")
+	private Integer total;
+
+	private RecordsResponse(LocalDate date, List<RecordDto> records, String receiptDate, Integer total) {
 		this.date = date;
 		this.records = records;
 		this.receiptDate = receiptDate;
+		this.total = total;
 	}
 
-	public static RecordsResponse from(LocalDate date, List<RecordDto> records, String receiptDate) {
-		return new RecordsResponse(date, records, receiptDate);
+	public static RecordsResponse from(LocalDate date, List<RecordDto> records, String receiptDate, Integer total) {
+		return new RecordsResponse(date, records, receiptDate, total);
 	}
 }

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -47,15 +47,10 @@ public class RecordService {
 		log.info("[RecordService.getRecords] 레코드 목록 조회 요청");
 		Member member = memberRepository.findByName(request.getWriter())
 				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
-		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member).stream()
-				.collect(Collectors.groupingByConcurrent(
-						record -> {
-							LocalDateTime dateTime = record.getCreatedAt();
-							return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
-						}
-				));
 
 		List<RecordsResponse> response = new ArrayList<>();
+
+		ConcurrentMap<LocalDate, List<Record>> map = ifThereIsADateSearchByDateGetList(request, member);
 
 		for (LocalDate date : map.keySet()) {
 			List<RecordDto> records = map.get(date).stream()
@@ -74,6 +69,37 @@ public class RecordService {
 
 		log.info("[RecordService.getRecords] 레코드 목록 조회 성공");
 		return response;
+	}
+
+	private ConcurrentMap<LocalDate, List<Record>> ifThereIsADateSearchByDateGetList(
+			RecordsRequest request,
+			Member member
+	) {
+		if (request.getDate() != null) {
+			LocalDate date = request.getDate();
+			ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMemberAndCreatedAtBetween(member,
+							DateTimeUtil.getStartOfDay(date), DateTimeUtil.getEndOfDay(date))
+					.stream()
+					.collect(Collectors.groupingByConcurrent(
+									record -> {
+										LocalDateTime dateTime = record.getCreatedAt();
+										return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
+									}
+							)
+					);
+			return map;
+		}
+
+		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member)
+				.stream()
+				.collect(Collectors.groupingByConcurrent(
+								record -> {
+									LocalDateTime dateTime = record.getCreatedAt();
+									return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
+								}
+						)
+				);
+		return map;
 	}
 
 	@Transactional

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -63,7 +63,7 @@ public class RecordService {
 							)
 					).collect(Collectors.toList());
 			records.sort((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt()));
-			response.add(RecordsResponse.from(date, records, yearMonthDateConversion(date)));
+			response.add(RecordsResponse.from(date, records, yearMonthDateConversion(date), records.size()));
 		}
 
 		response.sort((o1, o2) -> o2.getDate().compareTo(o1.getDate()));

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -1,5 +1,7 @@
 package com.todaysfailbe.record.service;
 
+import static com.todaysfailbe.common.utils.DateTimeUtil.*;
+
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -10,7 +12,6 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.todaysfailbe.common.utils.DateTimeUtil;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.repository.MemberRepository;
@@ -57,12 +58,12 @@ public class RecordService {
 					.map(record ->
 							RecordDto.from(
 									record,
-									DateTimeUtil.hourMinuteSecondConversion(record.getCreatedAt()),
+									hourMinuteSecondConversion(record.getCreatedAt()),
 									MemberDto.from(record.getMember())
 							)
 					).collect(Collectors.toList());
 			records.sort((o1, o2) -> o2.getCreatedAt().compareTo(o1.getCreatedAt()));
-			response.add(RecordsResponse.from(date, records));
+			response.add(RecordsResponse.from(date, records, yearMonthDateConversion(date)));
 		}
 
 		response.sort((o1, o2) -> o2.getDate().compareTo(o1.getDate()));
@@ -78,7 +79,7 @@ public class RecordService {
 		if (request.getDate() != null) {
 			LocalDate date = request.getDate();
 			ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMemberAndCreatedAtBetween(member,
-							DateTimeUtil.getStartOfDay(date), DateTimeUtil.getEndOfDay(date))
+							getStartOfDay(date), getEndOfDay(date))
 					.stream()
 					.collect(Collectors.groupingByConcurrent(
 									record -> {


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
delivery: v0.0.2배포
작업내역명(페이지명)

## 📋 작업사항
* [#53] delivery: v0.0.1배포 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/54
* [#55] refactor: 실패 기록 조회 시 날짜가 있다면 날짜에 해당하는 실패 기록만 조회 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/56
* [#57] refactor: 실패 기록 조회 시 영수증에 들어갈 날짜 형식 값도 같이 응답 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/58
* [#59] docs: Swagger MemberDto 오타 수정 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/60
* [#61] refactor: 실패 기록 조회 시 기록리스트 개수 반환하도록 추가 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/62
* delivery: v0.0.2배포 by @kdomo in https://github.com/TodaysFail/TodaysFail-BE/pull/64
## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
