### PR TITLE
[#67] test: 실패 기록 삭제 테스트코드 추가

### DIFF
--- a/src/main/java/com/todaysfailbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/todaysfailbe/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.todaysfailbe.common.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -23,6 +24,25 @@ public class GlobalExceptionHandler {
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorMessage> handleIllegalArgumentException(
 			IllegalArgumentException exception) {
+		String message = exception.getMessage();
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorMessage.from(exception, message));
+	}
+
+	@ExceptionHandler(BindException.class)
+	public ResponseEntity<ErrorMessage> handleBindException(
+			BindException exception) {
+		String message = exception.getBindingResult()
+				.getFieldError().getDefaultMessage();
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorMessage.from(exception, message));
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<ErrorMessage> handleException(
+			Exception exception) {
 		String message = exception.getMessage();
 
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/todaysfailbe/record/model/request/CreateRecordRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/CreateRecordRequest.java
@@ -18,7 +18,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateRecordRequest {
-	@NotBlank(message = "작성자을 필수입니다.")
+	@NotBlank(message = "작성자는 필수입니다.")
 	@ApiModelProperty(value = "작성자", required = true, example = "도모")
 	private String writer;
 

--- a/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
+++ b/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -14,8 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
+import com.todaysfailbe.record.model.request.DeleteRecordRequest;
 import com.todaysfailbe.record.service.RecordService;
 
 @WebMvcTest(RecordController.class)
@@ -28,9 +27,6 @@ class RecordControllerTest {
 
 	@Autowired
 	private ObjectMapper objectMapper;
-
-	@Mock
-	private Record mockRecord;
 
 	@Nested
 	@DisplayName("레코드를 생성할 때")
@@ -202,4 +198,39 @@ class RecordControllerTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("실패기록을 삭제할 때")
+	class 실패기록을_삭제할_때 {
+		@Test
+		@DisplayName("작성자를 입력하지 않았다면 예외가 발생한다.")
+		void 작성자를_입력하지_않았다면_예외가_발생한다() throws Exception {
+			// given
+
+			// when, then
+			mockMvc.perform(delete("/api/v1/record")
+							.contentType(MediaType.APPLICATION_JSON)
+							.param("recordId", "1"))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("작성자는 필수입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("BindException"));
+		}
+
+		@Test
+		@DisplayName("실패 기록 ID를 입력하지 않았다면 예외가 발생한다.")
+		void 실패_기록_ID를_입력하지_않았다면_예외가_발생한다() throws Exception {
+			// given
+			DeleteRecordRequest deleteRecordRequest = DeleteRecordRequest.builder()
+					.writer("도모")
+					.build();
+
+			// when, then
+			mockMvc.perform(delete("/api/v1/record")
+							.contentType(MediaType.APPLICATION_JSON)
+							.param("writer", "도모"))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("실패 기록 ID는 필수입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("BindException"));
+		}
+
+	}
 }

--- a/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
+++ b/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
@@ -29,8 +29,8 @@ class RecordControllerTest {
 	private ObjectMapper objectMapper;
 
 	@Nested
-	@DisplayName("레코드를 생성할 때")
-	class 레코드를_생성할_때 {
+	@DisplayName("실패기록을 생성할 때")
+	class 실패기록을_생성할_때 {
 		@Test
 		@DisplayName("작성자를 입력하지 않았다면 예외가 발생한다.")
 		void 작성자를_입력하지_않았다면_예외가_발생한다() throws Exception {

--- a/src/test/java/com/todaysfailbe/record/service/RecordServiceTest.java
+++ b/src/test/java/com/todaysfailbe/record/service/RecordServiceTest.java
@@ -19,6 +19,7 @@ import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.repository.MemberRepository;
 import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
+import com.todaysfailbe.record.model.request.DeleteRecordRequest;
 import com.todaysfailbe.record.repository.RecordRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +36,8 @@ class RecordServiceTest {
 
 	@Mock
 	private Member mockMember;
+	@Mock
+	private Member mockMemberOther;
 
 	@Mock
 	private Record mockRecord;
@@ -74,13 +77,106 @@ class RecordServiceTest {
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.");
 			given(request.getFeel())
 					.willReturn("다음에 더 잘하면 된다");
-			
+
 			given(memberRepository.findByName(anyString()))
 					.willReturn(Optional.of(mockMember));
 
 			// when, then
 			assertThatCode(() -> recordService.createRecord(request))
 					.doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	class 레코드를_삭제할_때 {
+		@Test
+		@DisplayName("닉네임으로 회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
+		void 닉네임으로_회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
+			// given
+			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
+			given(request.getWriter())
+					.willReturn("도모");
+			given(memberRepository.findByName(anyString()))
+					.willReturn(Optional.empty());
+
+			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
+
+			// when, then
+			assertThatThrownBy(() -> recordService.deleteRecord(request))
+					.isInstanceOf(IllegalArgumentException.class);
+			verify(memberRepository, times(1)).findByName(anyString());
+			verify(recordRepository, times(0)).delete(recordCaptor.capture());
+		}
+
+		@Test
+		@DisplayName("레코드가 존재하지 않는다면 예외를 발생시킨다")
+		void 레코드가_존재하지_않는다면_예외를_발생시킨다() {
+			// given
+			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
+			given(request.getWriter())
+					.willReturn("도모");
+			given(memberRepository.findByName(anyString()))
+					.willReturn(Optional.of(mockMember));
+			given(recordRepository.findById(anyLong()))
+					.willReturn(Optional.empty());
+
+			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
+
+			// when, then
+			assertThatThrownBy(() -> recordService.deleteRecord(request))
+					.isInstanceOf(IllegalArgumentException.class);
+			verify(memberRepository, times(1)).findByName(anyString());
+			verify(recordRepository, times(1)).findById(anyLong());
+			verify(recordRepository, times(0)).delete(recordCaptor.capture());
+		}
+
+		@Test
+		@DisplayName("삭제 요청자와 레코드 작성자가 다르다면 예외를 발생시킨다")
+		void 삭제_요청자와_레코드_작성자가_다르다면_예외를_발생시킨다() {
+			// given
+			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
+			given(request.getWriter())
+					.willReturn("도모");
+			given(memberRepository.findByName(anyString()))
+					.willReturn(Optional.of(mockMember));
+			given(recordRepository.findById(anyLong()))
+					.willReturn(Optional.of(mockRecord));
+			given(mockRecord.getMember())
+					.willReturn(mockMemberOther);
+
+			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
+
+			// when, then
+			assertThatThrownBy(() -> recordService.deleteRecord(request))
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("해당 레코드를 삭제할 권한이 없습니다.");
+			verify(memberRepository, times(1)).findByName(anyString());
+			verify(recordRepository, times(1)).findById(anyLong());
+			verify(recordRepository, times(0)).delete(recordCaptor.capture());
+		}
+
+		@Test
+		@DisplayName("정상적이라면 예외를 발생시키지 않는다.")
+		void 정상적이라면_예외를_발생시키지_않는() {
+			// given
+			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
+			given(request.getWriter())
+					.willReturn("도모");
+			given(memberRepository.findByName(anyString()))
+					.willReturn(Optional.of(mockMember));
+			given(recordRepository.findById(anyLong()))
+					.willReturn(Optional.of(mockRecord));
+			given(mockRecord.getMember())
+					.willReturn(mockMember);
+
+			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
+
+			// when, then
+			assertThatCode(() -> recordService.deleteRecord(request))
+					.doesNotThrowAnyException();
+			verify(memberRepository, times(1)).findByName(anyString());
+			verify(recordRepository, times(1)).findById(anyLong());
+			verify(recordRepository, times(1)).delete(recordCaptor.capture());
 		}
 	}
 


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
실패 기록 삭제 테스트코드 추가

## 📋 진행 사항
- [x] GlobalExceptionHandler에 BindException Handler 추가
- [x] 실패 기록 삭제 Service 테스트코드 추가
- [x] 실패 기록 삭제 Controller 테스트코드 추가

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
