### PR TITLE
[#75] feat, refactor, test: 회원가입, 로그인, 로그아웃 기능 추가

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    env:
+      ENCRYPT_SALT: ${{ secrets.TEST_ENCRYPT_SALT }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/src/main/java/com/todaysfailbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/todaysfailbe/common/exception/GlobalExceptionHandler.java
@@ -21,6 +21,15 @@ public class GlobalExceptionHandler {
 				.body(ErrorMessage.from(exception, message));
 	}
 
+	@ExceptionHandler(NotFoundUserInfoInSessionException.class)
+	public ResponseEntity<ErrorMessage> handleNotFoundUserInfoInSessionException(
+			NotFoundUserInfoInSessionException exception) {
+		String message = exception.getMessage();
+
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(ErrorMessage.from(exception, message));
+	}
+
 	@ExceptionHandler(IllegalArgumentException.class)
 	public ResponseEntity<ErrorMessage> handleIllegalArgumentException(
 			IllegalArgumentException exception) {

--- a/src/main/java/com/todaysfailbe/common/exception/NotFoundUserInfoInSessionException.java
+++ b/src/main/java/com/todaysfailbe/common/exception/NotFoundUserInfoInSessionException.java
@@ -1,0 +1,7 @@
+package com.todaysfailbe.common.exception;
+
+public class NotFoundUserInfoInSessionException extends RuntimeException {
+	public NotFoundUserInfoInSessionException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/todaysfailbe/common/utils/EncryptUtil.java
+++ b/src/main/java/com/todaysfailbe/common/utils/EncryptUtil.java
@@ -1,0 +1,34 @@
+package com.todaysfailbe.common.utils;
+
+import java.security.MessageDigest;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+@Component
+public class EncryptUtil {
+	private final String salt;
+
+	public EncryptUtil(@Value("${encrypt.salt}") String salt) {
+		Assert.notNull(salt, "salt 값은 null이 될 수 없습니다.");
+		this.salt = salt;
+	}
+
+	public String encrypt(String password) {
+		try {
+			MessageDigest md = MessageDigest.getInstance("SHA-256");
+			md.reset();
+			md.update(salt.getBytes());
+			byte[] input = md.digest(password.getBytes("UTF-8"));
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < input.length; i++) {
+				sb.append(Integer.toString((input[i] & 0xff) + 0x100, 16).substring(1));
+			}
+			return sb.toString();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}
+

--- a/src/main/java/com/todaysfailbe/common/utils/SessionUtil.java
+++ b/src/main/java/com/todaysfailbe/common/utils/SessionUtil.java
@@ -1,0 +1,37 @@
+package com.todaysfailbe.common.utils;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.stereotype.Component;
+
+import com.todaysfailbe.common.exception.NotFoundUserInfoInSessionException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionUtil {
+
+	private static final String PREFIX_USER_ID = "LOGIN_USER_ID";
+	private final HttpSession httpSession;
+
+	public void saveUserIdInSession(Long id) {
+		httpSession.setAttribute(PREFIX_USER_ID, id);
+	}
+
+	public Long findUserIdBySession() {
+		Object userId = httpSession.getAttribute(PREFIX_USER_ID);
+		if (userId == null) {
+			log.info("[SessionUtil.findUserIdBySession] 세션 조회 실패");
+			httpSession.invalidate();
+			throw new NotFoundUserInfoInSessionException("세션에 사용자 정보가 저장되어 있지 않습니다");
+		}
+		return Long.valueOf(userId.toString());
+	}
+
+	public void invalidateSession() {
+		httpSession.invalidate();
+	}
+}

--- a/src/main/java/com/todaysfailbe/member/controller/MemberController.java
+++ b/src/main/java/com/todaysfailbe/member/controller/MemberController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.todaysfailbe.member.model.request.CreateMemberRequest;
+import com.todaysfailbe.member.model.request.LoginMemberRequest;
+import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.service.MemberService;
 
 import io.swagger.annotations.ApiOperation;
@@ -47,6 +49,43 @@ public class MemberController {
 	}
 
 	@ApiOperation(
+			value = "로그인",
+			notes = "닉네임과 비밀번호를 입력받아 로그인을 진행합니다"
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / 로그인 완료"
+			),
+			@ApiResponse(
+					code = 400, message = "닉네임이나 비밀번호가 틀렸을 경우입니다"
+			)
+	})
+	@PostMapping("/login")
+	public ResponseEntity<Void> loginMember(@RequestBody @Valid LoginMemberRequest loginMemberRequest) {
+		log.info("[MemberController.loginMember] 회원 로그인 요청: {}", loginMemberRequest);
+		memberService.loginMember(loginMemberRequest);
+		log.info("[MemberController.loginMember] 회원 로그인 성공: {}", loginMemberRequest);
+		return ResponseEntity.ok().build();
+	}
+
+	@ApiOperation(
+			value = "로그아웃",
+			notes = "로그아웃을 진행합니다"
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / 로그아웃 완료"
+			)
+	})
+	@PostMapping("/logout")
+	public ResponseEntity<Void> logoutMember() {
+		log.info("[MemberController.logoutMember] 회원 로그아웃 요청");
+		memberService.logoutMember();
+		log.info("[MemberController.logoutMember] 회원 로그아웃 성공");
+		return ResponseEntity.ok().build();
+	}
+
+	@ApiOperation(
 			value = "닉네임 중복 체크",
 			notes = "닉네임 중복체크를 진행합니다. 중복되었다면 true, 중복되지 않았다면 false를 반환합니다"
 	)
@@ -59,5 +98,13 @@ public class MemberController {
 	public ResponseEntity<Boolean> checkDuplicateName(@PathVariable String name) {
 		log.info("[MemberController.checkDuplicateName] 중복 이름 체크 요청: {}", name);
 		return ResponseEntity.ok(memberService.checkDuplicateName(name));
+	}
+
+	@GetMapping("/info")
+	public ResponseEntity<MemberDto> getMemberInfo() {
+		log.info("[MemberController.getMemberInfo] 회원 정보 조회 요청");
+		MemberDto memberDto = memberService.getMemberInfo();
+		log.info("[MemberController.getMemberInfo] 회원 정보 조회 성공: {}", memberDto);
+		return ResponseEntity.ok(memberService.getMemberInfo());
 	}
 }

--- a/src/main/java/com/todaysfailbe/member/domain/Member.java
+++ b/src/main/java/com/todaysfailbe/member/domain/Member.java
@@ -30,12 +30,17 @@ public class Member extends BaseEntity {
 	@Column(name = "NAME")
 	private String name;
 
-	private Member(String name) {
+	@Column(name = "PASSWORD")
+	private String password;
+
+	private Member(String name, String password) {
 		Assert.hasText(name, "이름은 필수입니다.");
+		Assert.hasText(password, "비밀번호는 필수입니다.");
 		this.name = name;
+		this.password = password;
 	}
 
 	public static Member from(CreateMemberRequest request) {
-		return new Member(request.getName());
+		return new Member(request.getName(), request.getPassword());
 	}
 }

--- a/src/main/java/com/todaysfailbe/member/model/request/LoginMemberRequest.java
+++ b/src/main/java/com/todaysfailbe/member/model/request/LoginMemberRequest.java
@@ -20,7 +20,7 @@ import lombok.ToString;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class CreateMemberRequest {
+public class LoginMemberRequest {
 	@NotBlank(message = "닉네임은 필수입니다.")
 	@Size(max = 10, message = "닉네임은 10자 이하로 입력해주세요.")
 	@ApiModelProperty(value = "닉네임", required = true, example = "도모")

--- a/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
+++ b/src/main/java/com/todaysfailbe/member/model/response/MemberDto.java
@@ -18,7 +18,7 @@ public class MemberDto {
 	@ApiModelProperty(value = "회원 ID", required = true, example = "1")
 	private Long id;
 
-	@ApiModelProperty(value = "회원 이름", required = true, example = "도모")
+	@ApiModelProperty(value = "회원 닉네임", required = true, example = "도모")
 	private String name;
 
 	private MemberDto(Long id, String name) {

--- a/src/main/java/com/todaysfailbe/member/repository/MemberRepository.java
+++ b/src/main/java/com/todaysfailbe/member/repository/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Boolean existsByName(String name);
 
 	Optional<Member> findByName(String writer);
+
+	Optional<Member> findByNameAndPassword(String name, String password);
 }

--- a/src/main/java/com/todaysfailbe/member/service/MemberService.java
+++ b/src/main/java/com/todaysfailbe/member/service/MemberService.java
@@ -2,9 +2,13 @@ package com.todaysfailbe.member.service;
 
 import org.springframework.stereotype.Service;
 
+import com.todaysfailbe.common.utils.EncryptUtil;
+import com.todaysfailbe.common.utils.SessionUtil;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.exception.DuplicateNameException;
 import com.todaysfailbe.member.model.request.CreateMemberRequest;
+import com.todaysfailbe.member.model.request.LoginMemberRequest;
+import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -15,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class MemberService {
 	private final MemberRepository memberRepository;
+	private final EncryptUtil encryptUtil;
+	private final SessionUtil sessionUtil;
 
 	public void createMember(CreateMemberRequest request) {
 		log.info("[MemberService.createMember] 회원 생성 요청: {}", request);
@@ -22,12 +28,45 @@ public class MemberService {
 			log.info("[MemberService.createMember] {}는이미 존재하는 이름입니다.", request.getName());
 			throw new DuplicateNameException("이미 존재하는 이름입니다.");
 		}
-		memberRepository.save(Member.from(request));
+		request.setPassword(encryptUtil.encrypt(request.getPassword()));
+		Member member = memberRepository.save(Member.from(request));
+		sessionUtil.saveUserIdInSession(member.getId());
 		log.info("[MemberService.createMember] 회원 생성 성공");
 	}
 
 	public Boolean checkDuplicateName(String name) {
 		log.info("[MemberService.checkDuplicateName] 중복 이름 체크 요청: {}", name);
 		return memberRepository.existsByName(name);
+	}
+
+	public void loginMember(LoginMemberRequest request) {
+		log.info("[MemberService.loginMember] 회원 로그인 요청: {}", request);
+		request.setPassword(encryptUtil.encrypt(request.getPassword()));
+		Member member = memberRepository.findByNameAndPassword(request.getName(), request.getPassword())
+				.orElseThrow(() -> {
+					log.info("[MemberService.loginMember] 회원 로그인 실패 - 회원 정보 불일치: {}", request.getName());
+					throw new IllegalArgumentException("로그인에 실패하였습니다.");
+				});
+		sessionUtil.saveUserIdInSession(member.getId());
+		log.info("[MemberService.loginMember] 회원 로그인 성공: {}", request.getName());
+	}
+
+	public void logoutMember() {
+		log.info("[MemberService.loginMember] 회원 로그아웃 요청");
+		sessionUtil.invalidateSession();
+		log.info("[MemberService.loginMember] 회원 로그아웃 성공");
+	}
+
+	public MemberDto getMemberInfo() {
+		log.info("[MemberService.getMemberInfo] 회원 정보 조회 요청");
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> {
+					log.info("[MemberService.getMemberInfo] 회원 정보 조회 실패 - 존재하지 않는 회원: {}", userIdBySession);
+					throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+				});
+		MemberDto memberDto = MemberDto.from(member);
+		log.info("[MemberService.getMemberInfo] 회원 정보 조회 성공: {}", memberDto);
+		return memberDto;
 	}
 }

--- a/src/main/java/com/todaysfailbe/receipt/controller/ReceiptController.java
+++ b/src/main/java/com/todaysfailbe/receipt/controller/ReceiptController.java
@@ -37,7 +37,7 @@ public class ReceiptController {
 					code = 201, message = "API 정상 작동 / 영수증 등록 완료"
 			),
 			@ApiResponse(
-					code = 400, message = "중복 된 닉네임이 있을 경우입니다"
+					code = 400, message = "해당 날짜에 해당하는 실패 기록이 없는 경우입니다."
 			)
 	})
 	@PostMapping
@@ -57,7 +57,7 @@ public class ReceiptController {
 					code = 200, message = "API 정상 작동 / 영수증 조회 완료"
 			),
 			@ApiResponse(
-					code = 400, message = "영수증 번호가 잘못된 경우입니다."
+					code = 400, message = "존재하지 않는 영수증 번호일 경우입니다."
 			)
 	})
 	@GetMapping("/{receiptId}")

--- a/src/main/java/com/todaysfailbe/receipt/model/request/CreateReceiptRequest.java
+++ b/src/main/java/com/todaysfailbe/receipt/model/request/CreateReceiptRequest.java
@@ -2,7 +2,6 @@ package com.todaysfailbe.receipt.model.request;
 
 import java.time.LocalDate;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import org.springframework.format.annotation.DateTimeFormat;
@@ -22,10 +21,6 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateReceiptRequest {
-	@NotBlank(message = "작성자는 필수입니다.")
-	@ApiModelProperty(value = "작성자", required = true, example = "도모")
-	private String writer;
-
 	@NotNull(message = "날짜는 필수입니다.")
 	@DateTimeFormat(pattern = "yyyy-MM-dd")
 	@ApiModelProperty(value = "영수증을 생성 할 날짜", required = true, example = "2023-02-26")

--- a/src/main/java/com/todaysfailbe/record/controller/RecordController.java
+++ b/src/main/java/com/todaysfailbe/record/controller/RecordController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
 import com.todaysfailbe.record.model.request.DeleteRecordRequest;
-import com.todaysfailbe.record.model.request.RecordsRequest;
 import com.todaysfailbe.record.model.response.RecordsResponse;
 import com.todaysfailbe.record.service.RecordService;
 
@@ -54,34 +53,31 @@ public class RecordController {
 
 	@ApiOperation(
 			value = "실패 기록들을 조회합니다",
-			notes = "닉네임을 받아 해당 닉네임의 실패 기록들을 조회합니다"
+			notes = "사용자의 실패 기록들을 조회합니다"
 	)
 	@ApiResponses({
 			@ApiResponse(
 					code = 200, message = "API 정상 작동 / 실패 기록 목록 조회 성공"
-			),
-			@ApiResponse(
-					code = 400, message = "입력 값이 잘못되었을 경우입니다"
 			)
 	})
 	@GetMapping
-	public ResponseEntity<List<RecordsResponse>> getRecords(@Valid RecordsRequest recordsRequest) {
+	public ResponseEntity<List<RecordsResponse>> getRecords() {
 		log.info("[RecordController.getRecords] 레코드 목록 조회 요청");
-		List<RecordsResponse> response = recordService.getRecords(recordsRequest);
+		List<RecordsResponse> response = recordService.getRecords();
 		log.info("[RecordController.getRecords] 레코드 목록 조회 성공");
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 
 	@ApiOperation(
 			value = "실패 기록을 삭제합니다.",
-			notes = "닉네임과 실패 기록의 ID를 받아 해당 실패 기록을 삭제합니다."
+			notes = "기록의 ID를 받아 해당 실패 기록을 삭제합니다."
 	)
 	@ApiResponses({
 			@ApiResponse(
 					code = 200, message = "API 정상 작동 / 실패 기록 목록 조회 성공"
 			),
 			@ApiResponse(
-					code = 400, message = "해당 실패 기록이 존재하지 않거나 해당 실패 기록이 해당 닉네임의 것이 아닐 경우입니다."
+					code = 400, message = "존재하지 않는 실패 기록이거나 혹은 권한이 없는 경우입니다"
 			)
 	})
 	@DeleteMapping

--- a/src/main/java/com/todaysfailbe/record/model/request/CreateRecordRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/CreateRecordRequest.java
@@ -18,10 +18,6 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateRecordRequest {
-	@NotBlank(message = "작성자는 필수입니다.")
-	@ApiModelProperty(value = "작성자", required = true, example = "도모")
-	private String writer;
-
 	@NotBlank(message = "제목은 필수입니다.")
 	@Size(max = 17, message = "제목은 17자 이하로 입력해주세요.")
 	@ApiModelProperty(value = "제목", required = true, example = "핫케이크 태움")

--- a/src/main/java/com/todaysfailbe/record/model/request/DeleteRecordRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/DeleteRecordRequest.java
@@ -1,6 +1,5 @@
 package com.todaysfailbe.record.model.request;
 
-import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import io.swagger.annotations.ApiModel;
@@ -20,10 +19,6 @@ import lombok.ToString;
 @AllArgsConstructor
 @Setter
 public class DeleteRecordRequest {
-	@NotBlank(message = "작성자는 필수입니다.")
-	@ApiModelProperty(value = "작성자", required = true, example = "지우")
-	private String writer;
-
 	@NotNull(message = "실패 기록 ID는 필수입니다.")
 	@ApiModelProperty(value = "실패 기록 ID", required = true, example = "1")
 	private Long recordId;

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -12,13 +12,13 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.todaysfailbe.common.utils.SessionUtil;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.repository.MemberRepository;
 import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
 import com.todaysfailbe.record.model.request.DeleteRecordRequest;
-import com.todaysfailbe.record.model.request.RecordsRequest;
 import com.todaysfailbe.record.model.response.RecordDto;
 import com.todaysfailbe.record.model.response.RecordsResponse;
 import com.todaysfailbe.record.repository.RecordRepository;
@@ -30,28 +30,45 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class RecordService {
+	private final SessionUtil sessionUtil;
 	private final MemberRepository memberRepository;
 	private final RecordRepository recordRepository;
 
 	@Transactional
 	public void createRecord(CreateRecordRequest request) {
 		log.info("[RecordService.createRecord] 레코드 생성 요청");
-		Member member = memberRepository.findByName(request.getWriter())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> {
+					log.info("[RecordService.createRecord] 레코드 생성 실패 - 존재하지 않는 회원: {}", userIdBySession);
+					throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+				});
 
 		recordRepository.save(Record.of(member, request));
 		log.info("[RecordService.createRecord] 레코드 생성 성공");
 	}
 
 	@Transactional(readOnly = true)
-	public List<RecordsResponse> getRecords(RecordsRequest request) {
+	public List<RecordsResponse> getRecords() {
 		log.info("[RecordService.getRecords] 레코드 목록 조회 요청");
-		Member member = memberRepository.findByName(request.getWriter())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> {
+					log.info("[RecordService.getRecords] 레코드 생성 실패 - 존재하지 않는 회원: {}", userIdBySession);
+					throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+				});
 
 		List<RecordsResponse> response = new ArrayList<>();
 
-		ConcurrentMap<LocalDate, List<Record>> map = ifThereIsADateSearchByDateGetList(request, member);
+		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member)
+				.stream()
+				.collect(Collectors.groupingByConcurrent(
+								record -> {
+									LocalDateTime dateTime = record.getCreatedAt();
+									return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
+								}
+						)
+				);
 
 		for (LocalDate date : map.keySet()) {
 			List<RecordDto> records = map.get(date).stream()
@@ -72,45 +89,23 @@ public class RecordService {
 		return response;
 	}
 
-	private ConcurrentMap<LocalDate, List<Record>> ifThereIsADateSearchByDateGetList(
-			RecordsRequest request,
-			Member member
-	) {
-		if (request.getDate() != null) {
-			LocalDate date = request.getDate();
-			ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMemberAndCreatedAtBetween(member,
-							getStartOfDay(date), getEndOfDay(date))
-					.stream()
-					.collect(Collectors.groupingByConcurrent(
-									record -> {
-										LocalDateTime dateTime = record.getCreatedAt();
-										return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
-									}
-							)
-					);
-			return map;
-		}
-
-		ConcurrentMap<LocalDate, List<Record>> map = recordRepository.findAllByMember(member)
-				.stream()
-				.collect(Collectors.groupingByConcurrent(
-								record -> {
-									LocalDateTime dateTime = record.getCreatedAt();
-									return LocalDate.of(dateTime.getYear(), dateTime.getMonth(), dateTime.getDayOfMonth());
-								}
-						)
-				);
-		return map;
-	}
-
 	@Transactional
 	public void deleteRecord(DeleteRecordRequest request) {
-		Member member = memberRepository.findByName(request.getWriter())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+		log.info("[RecordService.deleteRecord] 레코드 삭제 요청");
+		Long userIdBySession = sessionUtil.findUserIdBySession();
+		Member member = memberRepository.findById(userIdBySession)
+				.orElseThrow(() -> {
+					log.info("[RecordService.deleteRecord] 레코드 삭제 실패 - 존재하지 않는 회원: {}", userIdBySession);
+					throw new IllegalArgumentException("존재하지 않는 회원입니다.");
+				});
 		Record record = recordRepository.findById(request.getRecordId())
-				.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 레코드입니다."));
+				.orElseThrow(() -> {
+					log.info("[RecordService.deleteRecord] 레코드 삭제 실패 - 존재하지 않는 레코드: {}", request.getRecordId());
+					throw new IllegalArgumentException("존재하지 않는 레코드입니다.");
+				});
 
 		if (!member.equals(record.getMember())) {
+			log.info("[RecordService.deleteRecord] 레코드 삭제 실패 - 해당 레코드를 삭제할 권한이 없음");
 			throw new IllegalArgumentException("해당 레코드를 삭제할 권한이 없습니다.");
 		}
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -2,7 +2,6 @@ spring:
   config:
     activate:
       on-profile: "dev"
-
   jpa:
     open-in-view: true
     hibernate:
@@ -13,3 +12,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+encrypt:
+  salt: ${ENCRYPT_SALT}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,5 @@ spring:
   h2:
     console:
       enabled: true
+encrypt:
+  salt: ${ENCRYPT_SALT}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,3 +13,5 @@ springfox:
   documentation:
     swagger-ui:
       base-url: "/api/v1/"
+encrypt:
+  salt: ${ENCRYPT_SALT}

--- a/src/test/java/com/todaysfailbe/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/todaysfailbe/member/controller/MemberControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.model.request.CreateMemberRequest;
+import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.service.MemberService;
 
 @WebMvcTest(MemberController.class)
@@ -38,10 +39,11 @@ class MemberControllerTest {
 	@DisplayName("회원을 생성할 때")
 	class 회원을_생성할_때 {
 		@Test
-		@DisplayName("name이 없으면 예외가 발생한다.")
-		void name이_없으면_예외가_발생한다() throws Exception {
+		@DisplayName("닉네임이 없으면 예외가 발생한다.")
+		void 닉네임이_없으면_예외가_발생한다() throws Exception {
 			//given
 			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+					.password("abcd1234")
 					.build();
 
 			// when, then
@@ -49,16 +51,17 @@ class MemberControllerTest {
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(createMemberRequest)))
 					.andExpect(status().isBadRequest())
-					.andExpect(jsonPath("$.message").value("이름은 필수입니다."))
+					.andExpect(jsonPath("$.message").value("닉네임은 필수입니다."))
 					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
 		}
 
 		@Test
-		@DisplayName("name이 10자를 초과하면 예외가 발생한다.")
-		void name이_10자를_초과하면_예외가_발생한다() throws Exception {
+		@DisplayName("닉네임이 10자를 초과하면 예외가 발생한다.")
+		void 닉네임이_10자를_초과하면_예외가_발생한다() throws Exception {
 			//given
 			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
 					.name("12345678901")
+					.password("abcd1234")
 					.build();
 
 			// when, then
@@ -66,7 +69,74 @@ class MemberControllerTest {
 							.contentType(MediaType.APPLICATION_JSON)
 							.content(objectMapper.writeValueAsString(createMemberRequest)))
 					.andExpect(status().isBadRequest())
-					.andExpect(jsonPath("$.message").value("이름은 10자 이하로 입력해주세요."))
+					.andExpect(jsonPath("$.message").value("닉네임은 10자 이하로 입력해주세요."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
+		}
+
+		@Test
+		@DisplayName("비밀번호가 없으면 예외가 발생한다.")
+		void 비밀번호가_없으면_예외가_발생한다() throws Exception {
+			// given
+			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+					.name("도모")
+					.build();
+			// when, then
+			mockMvc.perform(post("/api/v1/member")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(createMemberRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("비밀번호는 필수입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
+		}
+
+		@Test
+		@DisplayName("비밀번호가 8자보다 작으면 예외가 발생한다.")
+		void 비밀번호가_8자보다_작으면_예외가_발생한다() throws Exception {
+			// given
+			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+					.name("도모")
+					.password("1234567")
+					.build();
+			// when, then
+			mockMvc.perform(post("/api/v1/member")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(createMemberRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 영문, 숫자를 포함해야 합니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
+		}
+
+		@Test
+		@DisplayName("비밀번호가 영문만 포함하면 예외가 발생한다.")
+		void 비밀번호가_영문만_포함하면_예외가_발생한다() throws Exception {
+			// given
+			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+					.name("도모")
+					.password("abcdefgh")
+					.build();
+			// when, then
+			mockMvc.perform(post("/api/v1/member")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(createMemberRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 영문, 숫자를 포함해야 합니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
+		}
+
+		@Test
+		@DisplayName("비밀번호가 숫자만 포함하면 예외가 발생한다.")
+		void 비밀번호가_숫자만_포함하면_예외가_발생한다() throws Exception {
+			// given
+			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
+					.name("도모")
+					.password("12345678")
+					.build();
+			// when, then
+			mockMvc.perform(post("/api/v1/member")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(createMemberRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("비밀번호는 8자 이상, 영문, 숫자를 포함해야 합니다."))
 					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
 		}
 
@@ -76,6 +146,7 @@ class MemberControllerTest {
 			// given
 			CreateMemberRequest createMemberRequest = CreateMemberRequest.builder()
 					.name("주니")
+					.password("abcd1234")
 					.build();
 
 			// when, then
@@ -120,6 +191,31 @@ class MemberControllerTest {
 					)
 					.andExpect(status().isOk())
 					.andExpect(content().string("false"))
+					.andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("회원 정보를 조회할 때")
+	class 회원_정보를_조회할_때 {
+		@Test
+		@DisplayName("정상적이라면 회원 정보를 반환한다.")
+		void 정상적이라면_회원_정보를_반환한다() throws Exception {
+			// given
+			MemberDto memberDto = MemberDto.builder()
+					.id(1723L)
+					.name("세잇")
+					.build();
+			given(memberService.getMemberInfo())
+					.willReturn(memberDto);
+
+			// when, then
+			mockMvc.perform(get("/api/v1/member/info/")
+							.contentType(MediaType.APPLICATION_JSON)
+					)
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.id").value(1723L))
+					.andExpect(jsonPath("$.name").value("세잇"))
 					.andDo(print());
 		}
 	}

--- a/src/test/java/com/todaysfailbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/todaysfailbe/member/service/MemberServiceTest.java
@@ -13,6 +13,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.todaysfailbe.common.utils.EncryptUtil;
+import com.todaysfailbe.common.utils.SessionUtil;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.exception.DuplicateNameException;
 import com.todaysfailbe.member.model.request.CreateMemberRequest;
@@ -23,6 +25,12 @@ import com.todaysfailbe.member.repository.MemberRepository;
 class MemberServiceTest {
 	@Mock
 	private MemberRepository memberRepository;
+
+	@Mock
+	private EncryptUtil encryptUtil;
+
+	@Mock
+	private SessionUtil sessionUtil;
 
 	@InjectMocks
 	private MemberService memberService;
@@ -57,7 +65,10 @@ class MemberServiceTest {
 			// given
 			CreateMemberRequest createMemberRequest = mock(CreateMemberRequest.class);
 			given(createMemberRequest.getName()).willReturn("주니");
+			given(createMemberRequest.getPassword()).willReturn("1234");
 
+			given(encryptUtil.encrypt(anyString()))
+					.willReturn("encrypted password");
 			given(memberRepository.save(any()))
 					.willReturn(mockMember);
 

--- a/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
+++ b/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
-import com.todaysfailbe.record.model.request.DeleteRecordRequest;
 import com.todaysfailbe.record.service.RecordService;
 
 @WebMvcTest(RecordController.class)
@@ -32,31 +31,10 @@ class RecordControllerTest {
 	@DisplayName("실패기록을 생성할 때")
 	class 실패기록을_생성할_때 {
 		@Test
-		@DisplayName("작성자를 입력하지 않았다면 예외가 발생한다.")
-		void 작성자를_입력하지_않았다면_예외가_발생한다() throws Exception {
-			// given
-			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.title("핫케이크 태움")
-					.content("분명히 가스불을 약으로 했는데 "
-							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
-					.feel("다음에 더 잘하면 된다")
-					.build();
-
-			// when, then
-			mockMvc.perform(post("/api/v1/record")
-							.contentType(MediaType.APPLICATION_JSON)
-							.content(objectMapper.writeValueAsString(createRecordRequest)))
-					.andExpect(status().isBadRequest())
-					.andExpect(jsonPath("$.message").value("작성자는 필수입니다."))
-					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"));
-		}
-
-		@Test
 		@DisplayName("제목을 입력하지 않았다면 예외가 발생한다.")
 		void 제목을_입력하지_않았다면_예외가_발생한다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.content("분명히 가스불을 약으로 했는데 "
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
 					.feel("다음에 더 잘하면 된다")
@@ -76,7 +54,6 @@ class RecordControllerTest {
 		void 제목이_17자를_초과하면_예외가_발생한다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("일이삼사오육칠팔구십일이삼사오육칠팔")
 					.content("분명히 가스불을 약으로 했는데 "
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
@@ -97,7 +74,6 @@ class RecordControllerTest {
 		void 내용을_입력하지_않았다면_예외가_발생한다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("핫케이크 태움")
 					.feel("다음에 더 잘하면 된다")
 					.build();
@@ -122,7 +98,6 @@ class RecordControllerTest {
 			sb.append("일");
 
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("핫케이크 태움")
 					.content(sb.toString())
 					.feel("다음에 더 잘하면 된다")
@@ -142,7 +117,6 @@ class RecordControllerTest {
 		void 느낀점을_입력하지_않았다면_예외가_발생한다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("핫케이크 태움")
 					.content("분명히 가스불을 약으로 했는데 "
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
@@ -162,7 +136,6 @@ class RecordControllerTest {
 		void 느낀점이_20자를_초과하면_예외가_발생한다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("핫케이크 태움")
 					.content("분명히 가스불을 약으로 했는데 "
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
@@ -183,7 +156,6 @@ class RecordControllerTest {
 		void 입력_값이_정상이면_201_응답을_받는다() throws Exception {
 			// given
 			CreateRecordRequest createRecordRequest = CreateRecordRequest.builder()
-					.writer("도모")
 					.title("핫케이크 태움")
 					.content("분명히 가스불을 약으로 했는데 "
 							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.")
@@ -202,27 +174,9 @@ class RecordControllerTest {
 	@DisplayName("실패기록을 삭제할 때")
 	class 실패기록을_삭제할_때 {
 		@Test
-		@DisplayName("작성자를 입력하지 않았다면 예외가 발생한다.")
-		void 작성자를_입력하지_않았다면_예외가_발생한다() throws Exception {
-			// given
-
-			// when, then
-			mockMvc.perform(delete("/api/v1/record")
-							.contentType(MediaType.APPLICATION_JSON)
-							.param("recordId", "1"))
-					.andExpect(status().isBadRequest())
-					.andExpect(jsonPath("$.message").value("작성자는 필수입니다."))
-					.andExpect(jsonPath("$.errorSimpleName").value("BindException"));
-		}
-
-		@Test
 		@DisplayName("실패 기록 ID를 입력하지 않았다면 예외가 발생한다.")
 		void 실패_기록_ID를_입력하지_않았다면_예외가_발생한다() throws Exception {
 			// given
-			DeleteRecordRequest deleteRecordRequest = DeleteRecordRequest.builder()
-					.writer("도모")
-					.build();
-
 			// when, then
 			mockMvc.perform(delete("/api/v1/record")
 							.contentType(MediaType.APPLICATION_JSON)
@@ -230,6 +184,18 @@ class RecordControllerTest {
 					.andExpect(status().isBadRequest())
 					.andExpect(jsonPath("$.message").value("실패 기록 ID는 필수입니다."))
 					.andExpect(jsonPath("$.errorSimpleName").value("BindException"));
+		}
+
+		@Test
+		@DisplayName("입력 값이 정상이면 200 응답을 받는다.")
+		void 입력_값이_정상이면_200_응답을_받는다() throws Exception {
+			// given
+
+			// when, then
+			mockMvc.perform(delete("/api/v1/record")
+							.contentType(MediaType.APPLICATION_JSON)
+							.param("recordId", "2"))
+					.andExpect(status().isOk());
 		}
 
 	}

--- a/src/test/java/com/todaysfailbe/record/service/RecordServiceTest.java
+++ b/src/test/java/com/todaysfailbe/record/service/RecordServiceTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -18,12 +16,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.todaysfailbe.common.utils.SessionUtil;
 import com.todaysfailbe.member.domain.Member;
 import com.todaysfailbe.member.repository.MemberRepository;
 import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
 import com.todaysfailbe.record.model.request.DeleteRecordRequest;
-import com.todaysfailbe.record.model.request.RecordsRequest;
 import com.todaysfailbe.record.repository.RecordRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +32,9 @@ class RecordServiceTest {
 
 	@Mock
 	private RecordRepository recordRepository;
+
+	@Mock
+	private SessionUtil sessionUtil;
 
 	@InjectMocks
 	private RecordService recordService;
@@ -49,13 +50,11 @@ class RecordServiceTest {
 	@Nested
 	class 레코드를_생성할_때 {
 		@Test
-		@DisplayName("닉네임으로 회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
-		void 닉네임으로_회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
+		@DisplayName("회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
+		void 회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
 			// given
 			CreateRecordRequest request = mock(CreateRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.empty());
 
 			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
@@ -63,7 +62,7 @@ class RecordServiceTest {
 			// when, then
 			assertThatThrownBy(() -> recordService.createRecord(request))
 					.isInstanceOf(IllegalArgumentException.class);
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(0)).save(recordCaptor.capture());
 		}
 
@@ -72,8 +71,6 @@ class RecordServiceTest {
 		void 정상적이라면_예외를_발생시키지_않는() {
 			// given
 			CreateRecordRequest request = mock(CreateRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
 			given(request.getTitle())
 					.willReturn("핫케이크 태움");
 			given(request.getContent())
@@ -82,7 +79,7 @@ class RecordServiceTest {
 			given(request.getFeel())
 					.willReturn("다음에 더 잘하면 된다");
 
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 
 			// when, then
@@ -94,13 +91,11 @@ class RecordServiceTest {
 	@Nested
 	class 레코드를_삭제할_때 {
 		@Test
-		@DisplayName("닉네임으로 회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
-		void 닉네임으로_회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
+		@DisplayName("회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
+		void 회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
 			// given
 			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.empty());
 
 			ArgumentCaptor<Record> recordCaptor = ArgumentCaptor.forClass(Record.class);
@@ -108,7 +103,7 @@ class RecordServiceTest {
 			// when, then
 			assertThatThrownBy(() -> recordService.deleteRecord(request))
 					.isInstanceOf(IllegalArgumentException.class);
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(0)).delete(recordCaptor.capture());
 		}
 
@@ -117,9 +112,7 @@ class RecordServiceTest {
 		void 레코드가_존재하지_않는다면_예외를_발생시킨다() {
 			// given
 			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 			given(recordRepository.findById(anyLong()))
 					.willReturn(Optional.empty());
@@ -129,7 +122,7 @@ class RecordServiceTest {
 			// when, then
 			assertThatThrownBy(() -> recordService.deleteRecord(request))
 					.isInstanceOf(IllegalArgumentException.class);
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(0)).delete(recordCaptor.capture());
 		}
@@ -139,9 +132,7 @@ class RecordServiceTest {
 		void 삭제_요청자와_레코드_작성자가_다르다면_예외를_발생시킨다() {
 			// given
 			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 			given(recordRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockRecord));
@@ -154,7 +145,7 @@ class RecordServiceTest {
 			assertThatThrownBy(() -> recordService.deleteRecord(request))
 					.isInstanceOf(IllegalArgumentException.class)
 					.hasMessage("해당 레코드를 삭제할 권한이 없습니다.");
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(0)).delete(recordCaptor.capture());
 		}
@@ -164,9 +155,7 @@ class RecordServiceTest {
 		void 정상적이라면_예외를_발생시키지_않는() {
 			// given
 			DeleteRecordRequest request = mock(DeleteRecordRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 			given(recordRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockRecord));
@@ -178,7 +167,7 @@ class RecordServiceTest {
 			// when, then
 			assertThatCode(() -> recordService.deleteRecord(request))
 					.doesNotThrowAnyException();
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(1)).findById(anyLong());
 			verify(recordRepository, times(1)).delete(recordCaptor.capture());
 		}
@@ -187,64 +176,32 @@ class RecordServiceTest {
 	@Nested
 	class 레코드를_조회할_때 {
 		@Test
-		@DisplayName("닉네임으로 회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
-		void 닉네임으로_회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
+		@DisplayName("회원을 조회 시 찾을 수 없다면 예외를 발생시킨다")
+		void 회원을_조회_시_찾을_수_없다면_예외를_발생시킨다() {
 			// given
-			RecordsRequest request = mock(RecordsRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.empty());
 
 			// when, then
-			assertThatThrownBy(() -> recordService.getRecords(request))
+			assertThatThrownBy(() -> recordService.getRecords())
 					.isInstanceOf(IllegalArgumentException.class);
-			verify(memberRepository, times(1)).findByName(anyString());
+			verify(memberRepository, times(1)).findById(anyLong());
 		}
 
 		@Test
-		@DisplayName("날짜가 있다면 날짜에 해당하는 실패 기록만 조회한다")
-		void 날짜가_있다면_날짜에_해당하는_실패_기록만_조회한다() {
+		@DisplayName("모든 날짜에 해당하는 실패 기록만 조회한다")
+		void 모든_날짜에_해당하는_실패_기록만_조회한다() {
 			// given
-			RecordsRequest request = mock(RecordsRequest.class);
-			given(request.getWriter())
-					.willReturn("도모");
-			given(request.getDate())
-					.willReturn(null);
-			given(memberRepository.findByName(anyString()))
-					.willReturn(Optional.of(mockMember));
-
-			// when, then
-			assertThatCode(() -> recordService.getRecords(request))
-					.doesNotThrowAnyException();
-
-			verify(memberRepository, times(1)).findByName(anyString());
-			verify(recordRepository, times(1)).findAllByMember(mockMember);
-		}
-
-		@Test
-		@DisplayName("날짜가 없다면 모든 날짜에 해당하는 실패 기록만 조회한다")
-		void 날짜가_없다면_모든_날짜에_해당하는_실패_기록만_조회한다() {
-			// given
-			RecordsRequest request = mock(RecordsRequest.class);
 			LocalDate date = LocalDate.now();
-			given(request.getWriter())
-					.willReturn("도모");
-			given(request.getDate())
-					.willReturn(date);
-			given(memberRepository.findByName(anyString()))
+			given(memberRepository.findById(anyLong()))
 					.willReturn(Optional.of(mockMember));
 
 			// when, then
-			assertThatCode(() -> recordService.getRecords(request))
+			assertThatCode(() -> recordService.getRecords())
 					.doesNotThrowAnyException();
 
-			verify(memberRepository, times(1)).findByName(anyString());
-			verify(recordRepository, times(1)).findAllByMemberAndCreatedAtBetween(
-					mockMember,
-					LocalDateTime.of(date, LocalTime.MIN),
-					LocalDateTime.of(date, LocalTime.MAX)
-			);
+			verify(memberRepository, times(1)).findById(anyLong());
+			verify(recordRepository, times(1)).findAllByMember(mockMember);
 		}
 	}
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,3 +11,5 @@ spring:
   h2:
     console:
       enabled: true
+encrypt:
+  salt: ${ENCRYPT_SALT}


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
기존 로컬스토리지로만 되어있던 로그인 기능에서
회원의 닉네임과 비밀번호를 통해 로그인을 진행하도록 수정합니다.
## 📋 진행 사항
- [x] 회원가입 기능 추가
- [x] 로그인 기능 수정
- [x] 모든 영역에서 회원의 id로 회원을 조회하도록 변경
- [x] 모든 영역에서 테스트 코드 수정
- [x] SessionUtil 생성
- [x] EncryptUtil 생성
- [x] salt값 환경변수 추가

## 😉 참고사항
- 실패 기록 조회 시 입력 파라미터에 날짜 값 필요하지 않아 제거하였습니다.
- 모든 영역에서 회원의 정보를 조회할 때 닉네임으로 조회하지않아 모두 제거하였습니다. (세션을 사용하기 때문에 따로 값을 보내주지 않아도 됨)

close #75 
