### PR TITLE
[#77] feat, test: 레코드 단건 조회 기능 추가, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/todaysfailbe/record/controller/RecordController.java
+++ b/src/main/java/com/todaysfailbe/record/controller/RecordController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
 import com.todaysfailbe.record.model.request.DeleteRecordRequest;
+import com.todaysfailbe.record.model.response.RecordDto;
 import com.todaysfailbe.record.model.response.RecordsResponse;
 import com.todaysfailbe.record.service.RecordService;
 
@@ -65,6 +67,26 @@ public class RecordController {
 		log.info("[RecordController.getRecords] 레코드 목록 조회 요청");
 		List<RecordsResponse> response = recordService.getRecords();
 		log.info("[RecordController.getRecords] 레코드 목록 조회 성공");
+		return ResponseEntity.status(HttpStatus.OK).body(response);
+	}
+
+	@ApiOperation(
+			value = "실패 기록 단 건 조회합니다",
+			notes = "요청한 ID의 실패 기록을 조회합니다"
+	)
+	@ApiResponses({
+			@ApiResponse(
+					code = 200, message = "API 정상 작동 / 실패 기록 목록 조회 성공"
+			),
+			@ApiResponse(
+					code = 400, message = "존재하지 않는 실패 기록인 경우입니다"
+			)
+	})
+	@GetMapping("/{recordId}")
+	public ResponseEntity<RecordDto> getRecord(@PathVariable Long recordId) {
+		log.info("[RecordController.getRecord] 레코드 단 건 조회 요청");
+		RecordDto response = recordService.getRecord(recordId);
+		log.info("[RecordController.getRecord] 레코드 단 건 조회 성공");
 		return ResponseEntity.status(HttpStatus.OK).body(response);
 	}
 

--- a/src/main/java/com/todaysfailbe/record/service/RecordService.java
+++ b/src/main/java/com/todaysfailbe/record/service/RecordService.java
@@ -112,4 +112,20 @@ public class RecordService {
 		recordRepository.delete(record);
 		log.info("[RecordService.deleteRecord] 레코드 삭제 성공");
 	}
+
+	public RecordDto getRecord(Long recordId) {
+		log.info("[RecordService.getRecord] 레코드 단 건 조회 요청");
+		Record record = recordRepository.findById(recordId)
+				.orElseThrow(() -> {
+					log.info("[RecordService.getRecord] 레코드 단 건 조회 실패 - 존재하지 않는 레코드: {}", recordId);
+					throw new IllegalArgumentException("존재하지 않는 레코드입니다.");
+				});
+		RecordDto recordDto = RecordDto.from(
+				record,
+				hourMinuteSecondConversion(record.getCreatedAt()),
+				MemberDto.from(record.getMember())
+		);
+		log.info("[RecordService.getRecord] 레코드 단 건 조회 성공");
+		return recordDto;
+	}
 }

--- a/src/test/java/com/todaysfailbe/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/todaysfailbe/member/controller/MemberControllerTest.java
@@ -22,6 +22,7 @@ import com.todaysfailbe.member.model.response.MemberDto;
 import com.todaysfailbe.member.service.MemberService;
 
 @WebMvcTest(MemberController.class)
+@DisplayName("MemberController 테스트")
 class MemberControllerTest {
 	@MockBean
 	private MemberService memberService;

--- a/src/test/java/com/todaysfailbe/member/service/MemberServiceTest.java
+++ b/src/test/java/com/todaysfailbe/member/service/MemberServiceTest.java
@@ -22,6 +22,7 @@ import com.todaysfailbe.member.repository.MemberRepository;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
+@DisplayName("MemberService 테스트")
 class MemberServiceTest {
 	@Mock
 	private MemberRepository memberRepository;

--- a/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
+++ b/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
@@ -1,11 +1,17 @@
 package com.todaysfailbe.record.controller;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -13,10 +19,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todaysfailbe.member.domain.Member;
+import com.todaysfailbe.member.model.response.MemberDto;
+import com.todaysfailbe.record.domain.Record;
 import com.todaysfailbe.record.model.request.CreateRecordRequest;
+import com.todaysfailbe.record.model.response.RecordDto;
+import com.todaysfailbe.record.model.response.RecordsResponse;
 import com.todaysfailbe.record.service.RecordService;
 
 @WebMvcTest(RecordController.class)
+@DisplayName("RecordController 테스트")
 class RecordControllerTest {
 	@MockBean
 	private RecordService recordService;
@@ -26,6 +38,9 @@ class RecordControllerTest {
 
 	@Autowired
 	private ObjectMapper objectMapper;
+
+	@Mock
+	private RecordsResponse mockRecordsResponse;
 
 	@Nested
 	@DisplayName("실패기록을 생성할 때")
@@ -198,5 +213,129 @@ class RecordControllerTest {
 					.andExpect(status().isOk());
 		}
 
+	}
+
+	@Nested
+	@DisplayName("실패 기록들을 조회할 때")
+	class 실패_기록들을_조회할_때 {
+		@Test
+		@DisplayName("회원 정보를 찾을 수 없다면 예외가 발생한다.")
+		void 회원_정보를_찾을_수_없다면_예외가_발생한다() throws Exception {
+			// given
+			given(recordService.getRecords())
+					.willThrow(new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+			// when, then
+			mockMvc.perform(get("/api/v1/record")
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("존재하지 않는 회원입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("IllegalArgumentException"));
+		}
+
+		@Test
+		@DisplayName("입력 값이 정상이면 200 응답을 받는다.")
+		void 입력_값이_정상이면_200_응답을_받는다() throws Exception {
+			// given
+			Member mockMember = mock(Member.class);
+			Record mockRecord = mock(Record.class);
+			given(mockMember.getId())
+					.willReturn(857L);
+			given(mockMember.getName())
+					.willReturn("도모");
+			given(mockRecord.getId())
+					.willReturn(2L);
+			given(mockRecord.getTitle())
+					.willReturn("핫케이크 태움");
+			given(mockRecord.getContent())
+					.willReturn("분명히 가스불을 약으로 했는데 "
+							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.");
+			given(mockRecord.getFeel())
+					.willReturn("다음에 더 잘하면 된다");
+
+			MemberDto memberDto = MemberDto.from(mockMember);
+			RecordDto recordDto = RecordDto.from(mockRecord, "19:31:51", memberDto);
+			LocalDate localDate = LocalDate.of(2023, 2, 27);
+			RecordsResponse recordsResponse = RecordsResponse.from(localDate, List.of(recordDto),
+					"FEBRUARY 02 - 27, 2023", 1);
+
+			given(recordService.getRecords())
+					.willReturn(List.of(recordsResponse));
+
+			// when, then
+			mockMvc.perform(get("/api/v1/record")
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$[0].date").value("2023-02-27"))
+					.andExpect(jsonPath("$[0].records[0].id").value(2))
+					.andExpect(jsonPath("$[0].records[0].title").value("핫케이크 태움"))
+					.andExpect(jsonPath("$[0].records[0].content").value("분명히 가스불을 약으로 했는데 "
+							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다."))
+					.andExpect(jsonPath("$[0].records[0].feel").value("다음에 더 잘하면 된다"))
+					.andExpect(jsonPath("$[0].records[0].createdAt").value("19:31:51"))
+					.andExpect(jsonPath("$[0].records[0].member.id").value(857))
+					.andExpect(jsonPath("$[0].records[0].member.name").value("도모"))
+					.andExpect(jsonPath("$[0].receiptDate").value("FEBRUARY 02 - 27, 2023"))
+					.andExpect(jsonPath("$[0].total").value(1))
+					.andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("실패 기록을 단 건 조회할 때")
+	class 실패_기록을_단_건_조회할_때 {
+		@Test
+		@DisplayName("실패_기록을 찾지 못한다면 예외를 발생시킨다")
+		void 실패_기록을_찾지_못한다면_예외를_발생시킨다() throws Exception {
+			// given
+			given(recordService.getRecord(anyLong()))
+					.willThrow(new IllegalArgumentException("존재하지 않는 레코드입니다."));
+			// when, then
+			mockMvc.perform(get("/api/v1/record/{recordId}", 2)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("존재하지 않는 레코드입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("IllegalArgumentException"));
+		}
+
+		@Test
+		@DisplayName("입력 값이 정상이면 200 응답을 받는다.")
+		void 입력_값이_정상이면_200_응답을_받는다() throws Exception {
+			// given
+			Member mockMember = mock(Member.class);
+			Record mockRecord = mock(Record.class);
+			given(mockMember.getId())
+					.willReturn(857L);
+			given(mockMember.getName())
+					.willReturn("도모");
+			given(mockRecord.getId())
+					.willReturn(2L);
+			given(mockRecord.getTitle())
+					.willReturn("핫케이크 태움");
+			given(mockRecord.getContent())
+					.willReturn("분명히 가스불을 약으로 했는데 "
+							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다.");
+			given(mockRecord.getFeel())
+					.willReturn("다음에 더 잘하면 된다");
+
+			MemberDto memberDto = MemberDto.from(mockMember);
+			RecordDto recordDto = RecordDto.from(mockRecord, "19:31:51", memberDto);
+			given(recordService.getRecord(anyLong()))
+					.willReturn(recordDto);
+
+			// when, then
+			mockMvc.perform(get("/api/v1/record/{recordId}", 2)
+							.contentType(MediaType.APPLICATION_JSON))
+					.andExpect(status().isOk())
+					.andExpect(jsonPath("$.id").value(2))
+					.andExpect(jsonPath("$.title").value("핫케이크 태움"))
+					.andExpect(jsonPath("$.content").value("분명히 가스불을 약으로 했는데 "
+							+ "어느 순간 분명히 가스불을 약으로 했는데 어느 순간 재가 됐다."))
+					.andExpect(jsonPath("$.feel").value("다음에 더 잘하면 된다"))
+					.andExpect(jsonPath("$.createdAt").value("19:31:51"))
+					.andExpect(jsonPath("$.member.id").value(857))
+					.andExpect(jsonPath("$.member.name").value("도모"))
+					.andDo(print());
+		}
 	}
 }


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
레코드 단건 조회 기능을 추가
그에 따라 테스트코드 추가와 레코드 목록 조회 테스트코드 누락으로 함께 추가

## 📋 작업사항
- [x] 레코드 단 건 조회 기능 추가
- [x] 레코드 단 건 조회 테스트 (Controller, Service)
- [x] 레코드 여러 건 조회 테스트 코드 누락되어 함께 추가 

## 😉 참고사항
<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
