### PR TITLE
[#83] fix: 영수증조회 시 작성자 닉네임도 반환하도록 변경

### DIFF
--- a/src/main/java/com/todaysfailbe/receipt/domain/Receipt.java
+++ b/src/main/java/com/todaysfailbe/receipt/domain/Receipt.java
@@ -34,19 +34,23 @@ public class Receipt extends BaseEntity {
 	@Column(name = "RECEIPT_ID")
 	private UUID id;
 
+	private String name;
+
 	@ElementCollection
 	private List<Long> recordIds;
 
 	private LocalDate receiptDate;
 
-	private Receipt(List<Long> recordIds, LocalDate receiptDate) {
+	private Receipt(String writerName, List<Long> recordIds, LocalDate receiptDate) {
+		Assert.notNull(writerName, "작성자 이름은 필수입니다.");
 		Assert.notNull(recordIds, "실패 기록 ID 리스트는 필수입니다.");
 		Assert.notNull(receiptDate, "영수증 발급일은 필수입니다.");
+		this.name = name;
 		this.recordIds = recordIds;
 		this.receiptDate = receiptDate;
 	}
 
-	public static Receipt from(List<Long> recordIds, LocalDate receiptDate) {
-		return new Receipt(recordIds, receiptDate);
+	public static Receipt from(String name, List<Long> recordIds, LocalDate receiptDate) {
+		return new Receipt(name, recordIds, receiptDate);
 	}
 }

--- a/src/main/java/com/todaysfailbe/receipt/model/response/ReceiptResponse.java
+++ b/src/main/java/com/todaysfailbe/receipt/model/response/ReceiptResponse.java
@@ -24,17 +24,21 @@ public class ReceiptResponse {
 	@ApiModelProperty(value = "영수증 날짜", required = true, example = "FEBRUARY 02 - 26, 2023")
 	private String date;
 
-	@ApiModelProperty(value = "영수증 번호", required = true, example = "FEBRUARY 02 - 26, 2023")
+	@ApiModelProperty(value = "영수증 번호", required = true, example = "567cf5b4-0080-486f-836d-22a5db1540de")
 	private String uuid;
 
-	private ReceiptResponse(Integer total, List<ReceiptDto> receiptList, String date, String uuid) {
+	@ApiModelProperty(value = "작성자의 닉네임", required = true, example = "FEBRUARY 02 - 26, 2023")
+	private String writerName;
+
+	private ReceiptResponse(Integer total, List<ReceiptDto> receiptList, String date, String uuid, String writerName) {
 		this.total = total;
 		this.receiptList = receiptList;
 		this.date = date;
 		this.uuid = uuid;
+		this.writerName = writerName;
 	}
 
-	public static ReceiptResponse from(List<ReceiptDto> receiptList, String date, String uuid) {
-		return new ReceiptResponse(receiptList.size(), receiptList, date, uuid);
+	public static ReceiptResponse from(List<ReceiptDto> receiptList, String date, String uuid, String writerName) {
+		return new ReceiptResponse(receiptList.size(), receiptList, date, uuid, writerName);
 	}
 }

--- a/src/main/java/com/todaysfailbe/receipt/service/ReceiptService.java
+++ b/src/main/java/com/todaysfailbe/receipt/service/ReceiptService.java
@@ -55,7 +55,7 @@ public class ReceiptService {
 			throw new IllegalArgumentException("해당 날짜에 해당하는 실패 기록이 없습니다.");
 		}
 
-		Receipt receipt = receiptRepository.save(Receipt.from(list, request.getDate()));
+		Receipt receipt = receiptRepository.save(Receipt.from(member.getName(), list, request.getDate()));
 		log.info("[ReceiptService.createReceipt] 영수증 등록 완료: {}", request);
 		return receipt.getId().toString();
 	}
@@ -76,7 +76,8 @@ public class ReceiptService {
 		ReceiptResponse response = ReceiptResponse.from(
 				receiptDtoList,
 				yearMonthDateConversion(receipt.getReceiptDate()),
-				receiptId
+				receiptId,
+				receipt.getName()
 		);
 		log.info("[ReceiptService.getReceipt] 영수증 조회 완료: {}", response);
 		return response;


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
영수증조회 시 작성자 닉네임도 반환하도록 변경
## 📋 작업사항
- [x] 영수증조회 시 작성자 닉네임도 반환하도록 변경

## 😉 참고사항

<!--팀원들이 참고해야할 사항이 있으면 작성해주세요-->
