### PR TITLE
[#91] feat: 실패기록 수정 Request에 validation 추가

### DIFF
--- a/src/main/java/com/todaysfailbe/record/model/request/UpdateRecordRequest.java
+++ b/src/main/java/com/todaysfailbe/record/model/request/UpdateRecordRequest.java
@@ -1,6 +1,8 @@
 package com.todaysfailbe.record.model.request;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -23,15 +25,18 @@ public class UpdateRecordRequest {
 	@ApiModelProperty(value = "실패 기록 ID", required = true, example = "1")
 	private Long recordId;
 
-	@NotNull(message = "제목은 필수입니다.")
+	@NotBlank(message = "제목은 필수입니다.")
+	@Size(max = 17, message = "제목은 17자 이하로 입력해주세요.")
 	@ApiModelProperty(value = "변경 할 제목", required = true, example = "핫케이크 태움")
 	private String title;
 
-	@NotNull(message = "내용은 필수입니다.")
+	@NotBlank(message = "내용은 필수입니다.")
+	@Size(max = 300, message = "내용은 300자 이하로 입력해주세요.")
 	@ApiModelProperty(value = "변경 할 내용", required = true, example = "오늘 핫케이크 만들다가 실패했다.")
 	private String content;
 
-	@NotNull(message = "느낀점은 필수입니다.")
+	@NotBlank(message = "느낀점은 필수입니다.")
+	@Size(max = 20, message = "느낀점은 20자 이하로 입력해주세요.")
 	@ApiModelProperty(value = "변경 할 느낀점", required = true, example = "다음에 더 잘하면 된다")
 	private String feel;
 }

--- a/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
+++ b/src/test/java/com/todaysfailbe/record/controller/RecordControllerTest.java
@@ -382,6 +382,27 @@ class RecordControllerTest {
 		}
 
 		@Test
+		@DisplayName("제목이 17자를 초과하면 예외를 발생시킨다.")
+		void 제목이_17자를_초과하면_예외가_발생한다() throws Exception {
+			// given
+			UpdateRecordRequest updateRecordRequest = UpdateRecordRequest.builder()
+					.recordId(1L)
+					.title("일이삼사오육칠팔구십일이삼사오육칠팔")
+					.content("핫케이크를 타다가 불이 났다.")
+					.feel("다음에 더 잘하면 된다")
+					.build();
+
+			// when, then
+			mockMvc.perform(put("/api/v1/record/")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(updateRecordRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("제목은 17자 이하로 입력해주세요."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"))
+					.andDo(print());
+		}
+
+		@Test
 		@DisplayName("내용을 입력하지 않았다면 예외를 발생시킨다.")
 		void 내용을_입력하지_않았다면_예외를_발생시킨다() throws Exception {
 			// given
@@ -396,6 +417,32 @@ class RecordControllerTest {
 							.content(objectMapper.writeValueAsString(updateRecordRequest)))
 					.andExpect(status().isBadRequest())
 					.andExpect(jsonPath("$.message").value("내용은 필수입니다."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"))
+					.andDo(print());
+		}
+
+		@Test
+		@DisplayName("내용이 300자를 초과하면 예외가 발생한다.")
+		void 내용이_300자를_초과하면_예외가_발생한다() throws Exception {
+			// given
+			StringBuilder sb = new StringBuilder();
+			for (int i = 0; i < 30; i++) {
+				sb.append("일이삼사오육칠팔구십");
+			}
+			sb.append("일");
+
+			UpdateRecordRequest updateRecordRequest = UpdateRecordRequest.builder()
+					.recordId(1L)
+					.title("핫케이크 태움")
+					.content(sb.toString())
+					.feel("다음에 더 잘하면 된다")
+					.build();
+			// when, then
+			mockMvc.perform(put("/api/v1/record/")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(updateRecordRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("내용은 300자 이하로 입력해주세요."))
 					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"))
 					.andDo(print());
 		}
@@ -420,6 +467,27 @@ class RecordControllerTest {
 		}
 
 		@Test
+		@DisplayName("느낀점이 20자를 초과하면 예외가 발생한다.")
+		void 느낀점이_20자를_초과하면_예외가_발생한다() throws Exception {
+			// given
+			UpdateRecordRequest updateRecordRequest = UpdateRecordRequest.builder()
+					.recordId(1L)
+					.title("핫케이크 태움")
+					.content("핫케이크를 타다가 불이 났다.")
+					.feel("일이삼사오육칠팔구십일이삼사오육칠팔구십일")
+					.build();
+
+			// when, then
+			mockMvc.perform(put("/api/v1/record/")
+							.contentType(MediaType.APPLICATION_JSON)
+							.content(objectMapper.writeValueAsString(updateRecordRequest)))
+					.andExpect(status().isBadRequest())
+					.andExpect(jsonPath("$.message").value("느낀점은 20자 이하로 입력해주세요."))
+					.andExpect(jsonPath("$.errorSimpleName").value("MethodArgumentNotValidException"))
+					.andDo(print());
+		}
+
+		@Test
 		@DisplayName("입력 값이 정상이면 200 응답을 받는다.")
 		void 입력_값이_정상이면_200_응답을_받는다() throws Exception {
 			UpdateRecordRequest updateRecordRequest = UpdateRecordRequest.builder()
@@ -428,7 +496,7 @@ class RecordControllerTest {
 					.content("핫케이크를 타다가 불이 났다.")
 					.feel("다음에 더 잘하면 된다")
 					.build();
-			
+
 			// when, then
 			mockMvc.perform(put("/api/v1/record/")
 							.contentType(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
실패기록 수정 Request에 validation 추가

## 📋 작업사항
- [x] 실패기록 수정 Request에 validation 추가

## 😉 참고사항