### PR TITLE
[#93] fix: Modify record entity content column length to 300

### DIFF
--- a/src/main/java/com/todaysfailbe/record/domain/Record.java
+++ b/src/main/java/com/todaysfailbe/record/domain/Record.java
@@ -39,7 +39,7 @@ public class Record extends BaseEntity {
 	@Column(name = "TITLE")
 	private String title;
 
-	@Column(name = "CONTENT")
+	@Column(name = "CONTENT", length = 300)
 	private String content;
 
 	@Column(name = "FEEL")


### PR DESCRIPTION
<!--🚨 PR 날리기 전에 develop 브랜치에 merge하는지 확인해주세요!-->
<!-- 제목 양식 // 커밋타입: 작성한 이슈와 동일한 제목 -->
<!-- ex) feat: 로그인 기능 구현 -->
<!--제목의 형식이 알맞은지 확인해주세요!-->

## ⭐ 개요
레코드 엔티티 content 컬럼에 length를 255(default)에서 300으로 수정

## 📋 작업사항
- [x] 레코드 엔티티 content 컬럼에 length를 255(default)에서 300으로 수정

## 😉 참고사항
`@Cloumn` Annotation은 `ddl-auto: create`, `ddl-auto: create-drop`일때만 작동하니
테스트서버와 상용서버는 ddl script를 작성하여 적용하여야 함
